### PR TITLE
Add usage message

### DIFF
--- a/src/hnetd.c
+++ b/src/hnetd.c
@@ -98,6 +98,24 @@ void hncp_iface_glue(hncp_iface_user hiu, hncp h, hncp_glue g)
 	iface_register_user(&hiu->iu);
 }
 
+int usage() {
+  L_ERR( "Valid options are:\n"
+	 "\t-d dnsmasq_script\n"
+	 "\t-f dnsmasq_bonus_file\n"
+	 "\t-o odhcp_script\n"
+	 "\t-c pcp_script\n"
+	 "\t-n router_name\n"
+	 "\t-m domain_name\n"
+	 "\t-s pa_store file\n"
+	 "\t-p socket path\n"
+	 "\t--ip4prefix v.x.y.z/prefix\n"
+	 "\t--ip6prefix v:x:y:z::/prefix\n"
+	 "\t--ulaprefix v:x:y:z::/prefix\n"
+	 "\t--loglevel [0-9]\n"
+	 );
+    return(3);
+}
+
 int main(__unused int argc, char *argv[])
 {
 	hncp h;
@@ -174,10 +192,11 @@ int main(__unused int argc, char *argv[])
 			{ "ip4prefix",   required_argument,      NULL,           GOL_IPPREFIX },
 			{ "ulaprefix",   required_argument,      NULL,           GOL_ULAPREFIX },
 			{ "loglevel",    required_argument,      NULL,           GOL_LOGLEVEL },
+			{ "help",	 no_argument,		 NULL,           '?' },
 			{ NULL,          0,                      NULL,           0 }
 	};
 
-	while ((c = getopt_long(argc, argv, "d:f:o:n:r:s:p:m:c:", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "?d:f:o:n:r:s:p:m:c:", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'd':
 			sd_params.dnsmasq_script = optarg;
@@ -215,9 +234,10 @@ int main(__unused int argc, char *argv[])
 		case GOL_LOGLEVEL:
 			log_level = atoi(optarg);
 			break;
-		case '?':
+		default:
 			L_ERR("Unrecognized option");
-			return 3;
+		case '?': return usage();
+			  break;
 		}
 	}
 


### PR DESCRIPTION
If you are interested in a basic usage message, here you go. If you are interested in a man page I can do that too. 

note: I am still trying to wrap myself around this code. What I had kind of expected was more AHCP-like,
where you would specify something like

hnetd --server --ip6prefix 2001:a:b:c::/48 --ip4prefix 10.1.0.0/20 --ntpserver fd::1/128 eth0 wlan0

and a client would look like:

hnetd --client -6 --ip6want 64 eth0 eth1 eth2 eth3 # which would ask for ipv6 only, and combine the requests into a /62 request if possible.

Not clear to me is a relay mode either (where a router would redistribute hnetd info but not allocate any
addresses itself.

Still reading...
